### PR TITLE
Hooks for each OS

### DIFF
--- a/src/integrations.rs
+++ b/src/integrations.rs
@@ -107,7 +107,7 @@ fn create_pre_commit_hook() -> Result<(), ClientError> {
         fi
         TMPFILE=$(mktemp) || { echo "Failed to create temp file"; exit 1; }
         git diff --staged | ./target/debug/galactica code 'provide 1 sentence as a summary of the changes made to this code. Then skip a line and provide a short description of why the major changes were made, using bullet points if necessary.' > "$TMPFILE"
-        ${EDITOR:-notepad.exe} "$TMPFILE"
+        ${EDITOR:git config --get core.editor || echo 'notepad'} "$TMPFILE"
         COMMIT_MSG=$(cat "$TMPFILE")
         rm "$TMPFILE"
         echo "$COMMIT_MSG" | git commit -F -"#,

--- a/src/integrations.rs
+++ b/src/integrations.rs
@@ -99,25 +99,32 @@ fn create_hook(filepath: &str, script: &str) -> Result<(), ClientError> {
 }
 
 fn create_pre_commit_hook() -> Result<(), ClientError> {
-    
+    let mut editor = "";
+    let os = std::env::consts::OS; //this allows the executable to run on any machine as it checks at runtime as opposed to compile time with cfg!(target_os)
+    match os {
+        "linux" => editor = "vi",
+        "macos" => editor = "TextEdit",
+        "windows" => editor = "notepad",
+        _ => editor = "vi",
+    }
+  
     let tmp_file_creator = r#"#!/bin/bash
-    if [ -n "$GIT_EDITOR" ]; then
-    exit 0
-    fi
-    TMPFILE=$(mktemp) || { echo "Failed to create temp file"; exit 1; }
-    git diff --staged | ./target/debug/galactica code 'provide 1 sentence as a summary of the changes made to this code. Then skip a line and provide a short description of why the major changes were made, using bullet points if necessary.' > "$TMPFILE"
-    "#.to_string();
-    let var_string =  r#"${EDITOR:-$(git config --get core.editor || echo 'notepad')} "$TMPFILE""#;
-    let commit_string = r#"COMMIT_MSG=$(cat "$TMPFILE")
-    rm "$TMPFILE"
-    echo "$COMMIT_MSG" | git commit -F -"#;
+if [ -n "$GIT_EDITOR" ]; then
+exit 0
+fi
+TMPFILE=$(mktemp) || { echo "Failed to create temp file"; exit 1; }
+git diff --staged | ./target/debug/galactica code 'provide 1 sentence as a summary of the changes made to this code. Then skip a line and provide a short description of why the major changes were made, using bullet points if necessary.' > "$TMPFILE"
+${EDITOR:-$(git config --get core.editor || echo '"#.to_string();
+    let commit_string = r#"')} "$TMPFILE"
+COMMIT_MSG=$(cat "$TMPFILE")
+rm "$TMPFILE"
+echo "$COMMIT_MSG" | git commit -F -"#.to_string();
     
-    let combined_str = format!("{}\n{}\n{}",tmp_file_creator, var_string, commit_string);
+    let script = format!("{}{}{}",tmp_file_creator, editor, commit_string);
 
     create_hook(
         PRE_COMMIT_HOOK_FILEPATH,
-        &combined_str
-     ,
+        &script,
     )
 }
 

--- a/src/integrations.rs
+++ b/src/integrations.rs
@@ -82,7 +82,7 @@ fn create_hook(filepath: &str, script: &str, os: &str) -> Result<(), ClientError
     // Write the script to the pre-commit file
     if let Err(_e) = writeln!(hook_file, "{}", script){
         return Err(ClientError::IntegrationError(format!(
-            "Failed to make write pre-commit hook script executable"
+            "Failed to write pre-commit hook script"
         )));
 
     }

--- a/src/integrations.rs
+++ b/src/integrations.rs
@@ -4,6 +4,7 @@ use std::io::Write;
 use std::path::Path;
 use std::process::Command as com;
 use crate::errors::ClientError;
+use std::fs;
 use std::fs::OpenOptions;
 
 const PRE_COMMIT_HOOK_FILEPATH: &str = ".git/hooks/pre-commit";
@@ -38,7 +39,12 @@ pub fn cli_integrations(submatches: &ArgMatches) -> Result<(), ClientError> {
 }
 
 fn delete_pre_commit_hook() -> Result<(), ClientError> {
-    Err(ClientError::NotImplemented)
+    if let Err(_e) = fs::remove_file(PRE_COMMIT_HOOK_FILEPATH){
+        return Err(ClientError::IntegrationError(format!(
+            "Failed to delete pre-commit hook. Maybe you don't have one?"
+        )));
+    }
+    Ok(())
 }
 
 fn delete_prepare_commit_hook() -> Result<(), ClientError> {
@@ -113,7 +119,7 @@ if [ -n "$GIT_EDITOR" ]; then
 exit 0
 fi
 TMPFILE=$(mktemp) || { echo "Failed to create temp file"; exit 1; }
-git diff --staged | ./target/debug/galactica code 'provide 1 sentence as a summary of the changes made to this code. Then skip a line and provide a short description of why the major changes were made, using bullet points if necessary.' > "$TMPFILE"
+git diff --staged | galactica code 'provide 1 sentence as a summary of the changes made to this code. Then skip a line and provide a short description of why the major changes were made, using bullet points if necessary.' > "$TMPFILE"
 ${EDITOR:-$(git config --get core.editor || echo '"#.to_string();
     let commit_string = r#"')} "$TMPFILE"
 COMMIT_MSG=$(cat "$TMPFILE")

--- a/src/integrations.rs
+++ b/src/integrations.rs
@@ -107,7 +107,7 @@ fn create_pre_commit_hook() -> Result<(), ClientError> {
         fi
         TMPFILE=$(mktemp) || { echo "Failed to create temp file"; exit 1; }
         git diff --staged | ./target/debug/galactica code 'provide 1 sentence as a summary of the changes made to this code. Then skip a line and provide a short description of why the major changes were made, using bullet points if necessary.' > "$TMPFILE"
-        ${EDITOR:git config --get core.editor || echo 'notepad'} "$TMPFILE"
+        ${EDITOR:-$(git config --get core.editor || echo 'notepad')} "$TMPFILE"
         COMMIT_MSG=$(cat "$TMPFILE")
         rm "$TMPFILE"
         echo "$COMMIT_MSG" | git commit -F -"#,

--- a/src/integrations.rs
+++ b/src/integrations.rs
@@ -44,6 +44,7 @@ fn delete_pre_commit_hook() -> Result<(), ClientError> {
             "Failed to delete pre-commit hook. Maybe you don't have one?"
         )));
     }
+    println!("Pre-commit hook deleted successfully");
     Ok(())
 }
 
@@ -79,14 +80,17 @@ fn create_hook(filepath: &str, script: &str, os: &str) -> Result<(), ClientError
         };
 
     // Write the script to the pre-commit file
-    if let Err(_e) = writeln!(hook_file, "{}", script)
+    if let Err(_e) = writeln!(hook_file, "{}", script){
+        return Err(ClientError::IntegrationError(format!(
+            "Failed to make write pre-commit hook script executable"
+        )));
+
+    }
     // Make the pre-commit file executable
-    {
         let mut os_com = "chmod";
         if os == "windows" {
            os_com = "attrib";
         }
-
         let output = com::new(os_com)
             .arg("+x")
             .arg(hook_file_path.to_str().unwrap())
@@ -98,7 +102,6 @@ fn create_hook(filepath: &str, script: &str, os: &str) -> Result<(), ClientError
                 output
             )));
         }
-    }
     println!("Created {}", filepath);
 
     Ok(())


### PR DESCRIPTION
This needs to be tested with Linux/MacOS still. 
Only a pre-commit hook now so that you can write your own commit message without an editor opening. TMPFILE now created instead, and different for each OS.
making the hook executable works on windows. If the exe is not running on windows, chmod is used instead of "attrib" which in theory will work. 
Delete hooks functionality.